### PR TITLE
Add noexcept variants for `first_arg`

### DIFF
--- a/lib/metavirt/PathMatchers.h
+++ b/lib/metavirt/PathMatchers.h
@@ -30,6 +30,16 @@ struct first_arg<R (C::*)(Arg, Args...) const> {
   using type = Arg;
 };
 
+template <typename C, typename R, typename Arg, typename... Args>
+struct first_arg<R (C::*)(Arg, Args...) noexcept> {
+  using type = Arg;
+};
+
+template <typename C, typename R, typename Arg, typename... Args>
+struct first_arg<R (C::*)(Arg, Args...) const noexcept> {
+  using type = Arg;
+};
+
 template <typename T>
 struct first_arg {
   using type = typename first_arg<decltype(&T::operator())>::type;


### PR DESCRIPTION
Building `llvm-metavirt` through [Cage](https://git.rwth-aachen.de/tim.heldmann/cage), I encountered the following template error when building with LLVM 20:

```
error: type 'const llvm::Instruction *(metavirt::ErasedFn<const llvm::Instruction *>::*)(const llvm::Instruction *) noexcept' cannot be used prior to '::' because it has no members
   35 |   using type = typename first_arg<decltype(&T::operator())>::type;
```

This PR adds variants of `first_arg` for member functions that are marked `noexcept`.