### PR TITLE
Fix install paths

### DIFF
--- a/cmake/metavirtConfig.cmake.in
+++ b/cmake/metavirtConfig.cmake.in
@@ -2,8 +2,10 @@
 
 set_and_check(METAVIRT_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 set_and_check(METAVIRT_LIBRARY_DIR "@PACKAGE_LIBRARY_INSTALL_DIR@")
-set_and_check(METAVIRT_BINARY_DIR "@PACKAGE_BINARY_INSTALL_DIR@")
 set_and_check(METAVIRT_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_DIR@")
+
+# currently, an install metavirt does not include any binaries
+# set_and_check(METAVIRT_BINARY_DIR "@PACKAGE_BINARY_INSTALL_DIR@")
 
 macro (check_components comps_list)
   set(metavirt_FOUND true)

--- a/lib/metavirt/CMakeLists.txt
+++ b/lib/metavirt/CMakeLists.txt
@@ -28,8 +28,7 @@ metavirt_target_compile_opts(metavirt_Types)
 
 target_include_directories(
   metavirt_Types
-  PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/>
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/>
 )
 
 set_target_properties(

--- a/lib/metavirt/CMakeLists.txt
+++ b/lib/metavirt/CMakeLists.txt
@@ -43,7 +43,7 @@ set_target_properties(
 set(CONFIG_NAME metavirtTypes)
 set(TARGETS_EXPORT_NAME ${CONFIG_NAME}Targets)
 
-install(FILES Dimeta.h DimetaData.h DimetaIO.h
+install(FILES VirtCall.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )
 

--- a/lib/metavirt/DIRootType.cpp
+++ b/lib/metavirt/DIRootType.cpp
@@ -11,7 +11,7 @@
 
 #include "llvm/IR/Instructions.h"
 
-#include <VirtCall.h>
+#include <metavirt/VirtCall.h>
 
 namespace metavirt::root {
 


### PR DESCRIPTION
This PR proposes two changes:

- Don't set `METAVIRT_BINARY_DIR` in `metavirtConfig.cmake` as there are no binaries. Setting the variable to a non-existent path prevents metavirt from being includable in other projects via `find_package`.
- Use consistent include directories for the `metavirt_Types` target. This way, the header path is consistent, regardless of whether metavirt is included via `find_package` or ` FetchContent`