### PR TITLE
Expose public header in installed CMake target

### DIFF
--- a/lib/metavirt/CMakeLists.txt
+++ b/lib/metavirt/CMakeLists.txt
@@ -29,6 +29,7 @@ metavirt_target_compile_opts(metavirt_Types)
 target_include_directories(
   metavirt_Types
   PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/>
+  $<INSTALL_INTERFACE:include>
 )
 
 set_target_properties(


### PR DESCRIPTION
This is required in order to CMake to automatically find the public header when linking against metavirt using `target_link_libraries(cage PRIVATE metavirt::Types)`